### PR TITLE
chore(ci): SHA-pin third-party Actions (PTFM-18886) [skip ci]

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -9,11 +9,11 @@ jobs:
   create-tag:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: '0'
       - id: github-tag-action
-        uses: anothrNick/github-tag-action@1.75.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8  # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true


### PR DESCRIPTION
## Summary
SHA-pinned external GitHub Actions referenced by tag. For each `uses: foo/bar@v4`, replaced with `uses: foo/bar@<sha>  # v4`.

## Why
Tags are mutable. A compromised maintainer can re-point a tag (e.g. `v4`) to a malicious commit retroactively, even after we've reviewed and trusted the code at that tag. A SHA is immutable. The version comment keeps the line readable, and Dependabot bumps both the SHA and the comment together as new versions ship.

See [Confluence: GitHub Actions Best Practices & Recommendations / Security recommendations](https://kpler.atlassian.net/wiki/spaces/KSD/pages/243541590/GitHub+Actions+Best+Practices+Recommendations) for the rationale.

## Scope
- All `uses:` references are pinned, including internal `Kpler/*` actions. Dependabot will keep the SHA + version comment in sync as new versions ship.
- Local action references (`./...`) are not touched.
- Inline package installs (`pip install`, `uv add`, `apt install`, etc.) inside workflow scripts are intentionally OUT OF SCOPE for this PR and will be handled in a separate follow-up rollout.

## Skip-CI
Title and commit body carry `[skip ci]` so merging this PR does not trigger CI/CD on the default branch.

## Jira
[PTFM-18886](https://kpler.atlassian.net/browse/PTFM-18886)


[PTFM-18886]: https://kpler.atlassian.net/browse/PTFM-18886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ