### PR TITLE
chore(ci): add Dependabot cooldown for pre-commit hooks (PTFM-24090) [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Adds `package-ecosystem: "pre-commit"` with `cooldown: default-days: 7` to `.github/dependabot.yml`.

## Why

Without a cooldown, Dependabot opens PRs for pre-commit hook updates immediately on release. A 7-day minimum age gives time for hooks to stabilise and reduces noise from yanked or broken releases.

## Jira
[PTFM-24090](https://kpler.atlassian.net/browse/PTFM-24090)


[PTFM-24090]: https://kpler.atlassian.net/browse/PTFM-24090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ