### PR TITLE
chore(ci): switch pre-commit to Dependabot with SHA pinning (PTFM-24090)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown: # Reduce supply chain attacks risk
+      default-days: 7
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
        - id: check-merge-conflict
        - id: check-yaml
        - id: end-of-file-fixer
        - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.6
+    rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8 # v1.5.6
     hooks:
       - id: forbid-crlf
       - id: remove-crlf


### PR DESCRIPTION
## Summary

Switches pre-commit hook updates from the cron workflow to Dependabot.

- Adds `package-ecosystem: "pre-commit"` with a 7-day cooldown and
  `minor-and-patch` grouping to `.github/dependabot.yml`.
- SHA-pins all pre-commit hook `rev:` entries so Dependabot can keep them
  up-to-date without moving-tag risk.
- Removes `cron-update-pre-commit-hooks.yml` (now superseded by Dependabot).

## Why

Dependabot handles pre-commit hook updates with the same security guarantees
as GitHub Actions SHA pinning: immutable references, automatic updates via
the `# vX.Y.Z` comment, and a 7-day cooldown before PRs are opened.

## Validated

Tested on `platform-demo-api` — Dependabot detected the pre-commit ecosystem
and opened an update PR automatically after merge.

## Jira
[PTFM-24090](https://kpler.atlassian.net/browse/PTFM-24090)


[PTFM-24090]: https://kpler.atlassian.net/browse/PTFM-24090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ